### PR TITLE
Feat/#7 회원가입/로그인 로직 수정

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,5 +1,9 @@
-import axios, { AxiosInstance, AxiosResponse } from 'axios';
-import { getNewAccessToken } from './loginApi';
+import axios, {
+  AxiosInstance,
+  AxiosResponse,
+  InternalAxiosRequestConfig,
+} from 'axios';
+import { getNewAccessToken, setClientHeader } from './loginApi';
 
 const baseUrl = process.env.REACT_APP_SERVER_API_URL;
 
@@ -11,11 +15,12 @@ export const axiosInstance: AxiosInstance = axios.create({
 /** access token 갱신 interceptor */
 axiosInstance.interceptors.response.use(
   (res: AxiosResponse): AxiosResponse => {
+    console.log('👀response interceptor 정상적으로 통과!');
     return res;
   },
   (err): void => {
-    console.log('interceptor err ', err);
-    console.log('interceptor err msg ', err.response.data.message);
+    console.log('👀response interceptor err ', err);
+    console.log('👀response interceptor err msg ', err.response.data.message);
     if (err.response.data.message == '토큰 유효기간 만료.') {
       const refreshToken = window.localStorage.getItem('refresh_token');
       axiosInstance.defaults.headers['Refreshtoken'] = refreshToken;
@@ -24,3 +29,14 @@ axiosInstance.interceptors.response.use(
     throw err;
   }
 );
+
+/** 요청 이전 access token 존재시 넣어주기 */
+axiosInstance.interceptors.request.use((config: InternalAxiosRequestConfig) => {
+  console.log('👀request interceptor start');
+  const accessToken = window.localStorage.getItem('access_token');
+  if (accessToken) {
+    console.log('👀request interceptor accessToken exists');
+    setClientHeader(accessToken);
+  }
+  return config;
+});

--- a/src/api/loginApi.ts
+++ b/src/api/loginApi.ts
@@ -151,6 +151,10 @@ export const confirmNickname = async (nickname: string) => {
 
 /** 로그인 유저 정보 */
 export const verifyUser = () => {
+  const token = window.localStorage.getItem('access_token');
+  if (token) {
+    setClientHeader(token);
+  }
   return axiosInstance.get(`/accesstoken`).then((response) => {
     return response.data;
   });

--- a/src/api/loginApi.ts
+++ b/src/api/loginApi.ts
@@ -12,11 +12,11 @@ const tokenHandler = (accessToken: string, refreshToken?: string) => {
   if (refreshToken) {
     window.localStorage.setItem('refresh_token', refreshToken);
   }
+};
 
-  // 헤더에 토큰 세팅
-  const token = `Bearer%${window.localStorage.getItem('access_token')}`;
-  axiosInstance.defaults.headers['Accesstoken'] = token;
-  console.log('setting access token to header: ', token);
+export const setClientHeader = (accessToken: string) => {
+  axiosInstance.defaults.headers['Accesstoken'] = `Bearer%${accessToken}`;
+  console.log('setting access token to header: ', `Bearer%${accessToken}`);
 };
 
 /** 카카오 로그인 */
@@ -165,7 +165,7 @@ export const getNewAccessToken = () => {
     // 새로 받은 액세스 토큰 넣어주기
     const accessToken = response.headers['accesstoken'].replace('Bearer%', '');
     tokenHandler(accessToken);
-
+    setClientHeader(accessToken);
     console.log('Got new access token', response.data);
     return response.data;
   });

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -4,7 +4,7 @@ import { useVerifyUser } from 'hooks';
 import { StLoadingSpinner } from 'components/common';
 
 const ProtectedRoute = ({ element }: { element: JSX.Element }) => {
-  const { data, isLoading, isError } = useVerifyUser(true);
+  const { isLoading, isError, isSuccess } = useVerifyUser(true);
 
   useEffect(() => {
     if (!isLoading && isError) {
@@ -16,7 +16,13 @@ const ProtectedRoute = ({ element }: { element: JSX.Element }) => {
     return <StLoadingSpinner />;
   }
 
-  return data && data.nickname ? element : <Navigate to="/login" replace />;
+  if (isError) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (isSuccess) {
+    return element;
+  }
 };
 
 export default ProtectedRoute;


### PR DESCRIPTION
api 요청시 토큰 전달 오류, 로그인 필요한 페이지 새로고침시 로그인 풀리는 이슈 수정하였습니다.

### 회원가입/로그인 로직 수정
- `src/api/api.ts` `src/api/loginApi.ts` : 헤더에 토큰 추가 인터셉터 구현
### 페이지 새로고침시 로그인 풀리는 이슈 수정
- `src/routes/ProtectedRoute.tsx` : 로직 수정