### PR TITLE
Feat/#30 검색 결과 지도 보기 페이지 스타일링 수정, 이미지 preload 적용

### DIFF
--- a/src/assets/icons/CurrentPosition.svg
+++ b/src/assets/icons/CurrentPosition.svg
@@ -1,0 +1,8 @@
+<svg width="29" height="29" viewBox="0 0 29 29" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14.5 1.8125V5.4375" stroke="#0066FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M14.5 23.5625V27.1875" stroke="#0066FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M23.5625 14.5H27.1875" stroke="#0066FF" stroke-width="2" stroke-linecap="round"/>
+<path d="M1.8125 14.5H5.4375" stroke="#0066FF" stroke-width="2" stroke-linecap="round"/>
+<circle cx="14.5" cy="14.5" r="13.5" stroke="#0066FF" stroke-width="2"/>
+<circle cx="14.5" cy="14.5" r="2.71875" fill="#0066FF"/>
+</svg>

--- a/src/components/common/BackButton/BackButton.styles.ts
+++ b/src/components/common/BackButton/BackButton.styles.ts
@@ -12,4 +12,5 @@ export const StBackButton = styled.button`
   justify-content: center;
   align-items: center;
   z-index: 1000;
+  filter: drop-shadow(0px 2px 10px rgba(0, 0, 0, 0.25));
 `;

--- a/src/pages/SearchResultMapPage/CurrentPosButton/CurrentPosButton.styles.ts
+++ b/src/pages/SearchResultMapPage/CurrentPosButton/CurrentPosButton.styles.ts
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+
+export const StCurrentPosButton = styled.button`
+  width: 53px;
+  height: 53px;
+  border-radius: 50%;
+  background: #ffffff;
+  border: 0.5px solid #cecece;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  bottom: 50px;
+  right: 20px;
+  box-shadow: 0px 2px 10px 0px rgba(0, 0, 0, 0.2);
+`;

--- a/src/pages/SearchResultMapPage/CurrentPosButton/CurrentPosButton.tsx
+++ b/src/pages/SearchResultMapPage/CurrentPosButton/CurrentPosButton.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { ReactComponent as Icon } from 'assets/icons/CurrentPosition.svg';
+import { StCurrentPosButton } from './CurrentPosButton.styles';
+
+export const CurrentPosButton = ({ onClick }: { onClick: () => void }) => {
+  return (
+    <StCurrentPosButton onClick={onClick}>
+      <Icon />
+    </StCurrentPosButton>
+  );
+};

--- a/src/pages/SearchResultMapPage/SearchResultMapPage.styles.ts
+++ b/src/pages/SearchResultMapPage/SearchResultMapPage.styles.ts
@@ -18,13 +18,5 @@ export const StResultMapContainer = styled.div`
       top: 20px;
       left: 20px;
     }
-
-    // 현위치 버튼
-    &:last-of-type {
-      width: 50px;
-      height: 50px;
-      bottom: 50px;
-      right: 20px;
-    }
   }
 `;

--- a/src/pages/SearchResultMapPage/SearchResultMapPage.tsx
+++ b/src/pages/SearchResultMapPage/SearchResultMapPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Map } from 'components/common';
 import { BackButton } from 'components/common';
 import { CurrentPosButton } from './CurrentPosButton/CurrentPosButton';
@@ -19,6 +19,10 @@ export const SearchResultMapPage = ({
     null
   );
   const hasInitialMapPosSet = useRef<boolean>(false);
+  const tooltipImgPreload = () => {
+    const img = new Image();
+    img.src = Tooltip;
+  };
   const mapInstance = useRef<kakao.maps.Map | null>(null);
   const markerImage = new kakao.maps.MarkerImage(
     Marker,
@@ -162,6 +166,10 @@ export const SearchResultMapPage = ({
       setCenter(mapInstance.current, initialMapPos, false); // 첫 번째 마커 좌표로 지도 이동
     }
   }, [initialMapPos]);
+
+  useLayoutEffect(() => {
+    tooltipImgPreload();
+  }, []);
 
   return (
     <StResultMapContainer>

--- a/src/pages/SearchResultMapPage/SearchResultMapPage.tsx
+++ b/src/pages/SearchResultMapPage/SearchResultMapPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Map } from 'components/common';
-import { Button, BackButton } from 'components/common';
+import { BackButton } from 'components/common';
+import { CurrentPosButton } from './CurrentPosButton/CurrentPosButton';
 import Marker from 'assets/icons/Marker.png';
 import MarkerSelected from 'assets/icons/MarkerSelected.png';
 import { StResultMapContainer } from './SearchResultMapPage.styles';
@@ -148,6 +149,14 @@ export const SearchResultMapPage = ({
     onToggle();
   };
 
+  const onCurrentPosHandler = () => {
+    if (mapInstance.current) {
+      moveToCurrentLocation(mapInstance.current);
+    } else {
+      console.log('no map instance found');
+    }
+  };
+
   useEffect(() => {
     if (initialMapPos && mapInstance.current) {
       setCenter(mapInstance.current, initialMapPos, false); // 첫 번째 마커 좌표로 지도 이동
@@ -158,18 +167,7 @@ export const SearchResultMapPage = ({
     <StResultMapContainer>
       <Map width="100%" height="100%" initMap={initMap} />
       <BackButton onClick={onBackHandler} />
-      <Button
-        type="circleFill"
-        onClick={() => {
-          if (mapInstance.current) {
-            moveToCurrentLocation(mapInstance.current);
-          } else {
-            console.log('no map instance found');
-          }
-        }}
-      >
-        현위치
-      </Button>
+      <CurrentPosButton onClick={onCurrentPosHandler} />
     </StResultMapContainer>
   );
 };


### PR DESCRIPTION
### 검색 결과 지도보기 추가 디자인 적용
- `src/components/common/BackButton/BackButton.styles.ts` `src/pages/SearchResultMapPage/CurrentPosButton/CurrentPosButton.styles.ts` `src/pages/SearchResultMapPage/CurrentPosButton/CurrentPosButton.tsx` `src/pages/SearchResultMapPage/SearchResultMapPage.styles.ts` : 검색결과 지도보기 현위치 디자인 적용

### 이미지 preload 적용
마커 클릭시 툴팁 이미지가 로드되지 않아 화면이 깨지는 문제가 있어 preload 적용하였습니다.
- `src/pages/SearchResultMapPage/SearchResultMapPage.styles.ts` `src/pages/SearchResultMapPage/SearchResultMapPage.tsx` : 툴팁 배경 이미지 preload 적용