### PR TITLE
Feat/#118 반응형 공통 믹스인 추가

### DIFF
--- a/src/pages/KakaoCallbackPage/KakaoCalbackPage.styles.ts
+++ b/src/pages/KakaoCallbackPage/KakaoCalbackPage.styles.ts
@@ -3,6 +3,7 @@ import { theme } from 'style/theme';
 
 export const StLoginContainer = styled.div`
   ${theme.authLayout};
+  height: 100vh;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/pages/KakaoCallbackPage/KakaoCallbackPage.tsx
+++ b/src/pages/KakaoCallbackPage/KakaoCallbackPage.tsx
@@ -4,7 +4,6 @@ import { useMutation } from '@tanstack/react-query';
 import { useVerifyUser } from 'hooks';
 import { useNavigate } from 'react-router-dom';
 import { StLoginContainer } from './KakaoCalbackPage.styles';
-import { CommonLayout } from 'components/layout';
 import { StLoadingSpinner } from 'components/common';
 import { ReactComponent as Logo } from 'assets/images/Dongdong.svg';
 
@@ -34,11 +33,9 @@ export const KakaoCallbackPage = () => {
   }
 
   return (
-    <CommonLayout>
-      <StLoginContainer>
-        <Logo />
-        <StLoadingSpinner />
-      </StLoginContainer>
-    </CommonLayout>
+    <StLoginContainer>
+      <Logo />
+      <StLoadingSpinner />
+    </StLoginContainer>
   );
 };

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -24,6 +24,7 @@ const maxSizes = {
   maxWidth: '390px',
   maxHeight: '850px',
 };
+
 const authLayout = css`
   width: 100%;
   height: 100%;
@@ -60,6 +61,20 @@ const getAuthViewPoint = (page: string) => {
   }
 };
 
+// 반응형 최상위 컴포넌트 믹스인
+const responsiveLayout = css`
+  width: 100%;
+  height: 100%;
+`;
+
+// 반응형 콘텐츠 감싸는 컴포넌트 믹스인
+const responsiveContainer = css`
+  width: 100%;
+  height: 100%;
+  max-width: ${size.tablet};
+  margin: 0 auto;
+`;
+
 export const theme = {
   ...colors,
   ...maxSizes,
@@ -78,6 +93,8 @@ export const theme = {
     borderRadius: '0.8rem',
   },
   getAuthViewPoint,
+  responsiveLayout,
+  responsiveContainer,
 };
 
 // 사용법


### PR DESCRIPTION
### 반응형 공통 믹스인 추가
`src/style/theme.ts` 에 반응형용 공통 믹스인 추가하였습니다.
```javascript
// 반응형 최상위 컴포넌트 믹스인
const responsiveLayout = css`
  width: 100%;
  height: 100%;
`;

// 반응형 콘텐츠 감싸는 컴포넌트 믹스인
const responsiveContainer = css`
  width: 100%;
  height: 100%;
  max-width: ${size.tablet};
  margin: 0 auto;
`;
```
**👀사용 방법**
- 컴포넌트는 1) 페이지 전체를 감싸는 태그, 2) 반응형이 적용될 콘텐츠 랩핑 태그로 구성됩니다.
- 1에는 responsiveLayout, 2에는 responsiveContainer를 적용해줍니다.
```javascript
import styled from 'styled-components';
import { theme } from 'style/theme';

// 1 예시
export const StCommonLoginLayout = styled.div`
  ${theme.responsiveLayout};
`;

// 2 예시
export const StCommonLoginContainer = styled.div`
  ${theme.responsiveContainer};
`;
```

3조 짱짱맨 너무조아 화이띵
